### PR TITLE
Reference/citation check

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {
     "inkscape_path": "/Applications/Inkscape.app/Contents/MacOS/inkscape",
     "libreoffice_path": "/Applications/LibreOffice.app/Contents/MacOS/soffice",
-    "python_path": "/Users/pnb/anaconda3/envs/paper_convert/bin/python"
+    "python_path": "/Users/pnb/anaconda3/envs/paper_convert/bin/python",
+    "anystyle_path" : "/home/aolney/gems/bin/anystyle"
 }

--- a/main_docx.py
+++ b/main_docx.py
@@ -59,7 +59,7 @@ docx_conv.fix_references()
 print('Formatting authors')
 shared_utils.wrap_author_divs(docx_conv.soup)
 print('Checking styles')
-shared_utils.check_styles(docx_conv.soup)
+shared_utils.check_styles(docx_conv.soup,args.output_dir)
 
 # Save result
 print('Saving result')

--- a/main_latex.py
+++ b/main_latex.py
@@ -92,7 +92,7 @@ print('Removing unused IDs')
 texer.remove_unused_ids()
 
 print('Checking styles')
-shared_utils.check_styles(soup)
+shared_utils.check_styles(soup,args.output_dir)
 
 # Save result
 print('Saving result')

--- a/messages.json
+++ b/messages.json
@@ -87,6 +87,13 @@
                 "help": "Make sure you used the appropriate \\cite command and square brackets citation style."
             }
         },
+        "incomplete_reference": {
+            "message": "An entry in the reference section appears to be incomplete",
+            "help": "Find the numbered entry in your reference section and add the missing elements. If we did not correctly recognize the entry's type, the warning may be invalid.",
+            "tex": {
+                "help": "Check that the missing elements are in your Bibtex. If you see them but they don't appear in the PDF, you may have them in the wrong Bibtex field"
+            }
+        },
         "alt_text_missing": {
             "message": "Missing alt text for image",
             "help": "Follow the instructions in the template for adding alt text to images. Every image needs alt text to ensure the paper can be understood by people using screen reader software. Additionally, alt text is used by the HTML conversion program to identify each image, so alt text must be unique for each image; things like image sizes may be wrong otherwise.",

--- a/messages.json
+++ b/messages.json
@@ -80,6 +80,21 @@
                 "help": "Make sure you used the \\bibliographystyle{abbrv} and \\bibliography{sigproc} (or whatever your .bib file is named instead of sigproc.bib) commands in your paper."
             }
         },
+        "no_references_found_in_reference_section": {
+            "message": "No reference section with references found",
+            "help": "Check that your reference section is called 'REFERENCES' and uses the correct style.",
+            "tex": {
+                "help": "Make sure you used the appropriate section command and bibtex style."
+            }
+        },
+        "no_citations_found_in_text": {
+            "message": "No citations found in the text",
+            "help": "Check that your in-text citations use the correct numbered style, e.g. [1].",
+            "tex": {
+                "help": "Make sure you used the appropriate \\cite command and square brackets citation style."
+            }
+        },
+        
         "mismatched_refs": {
             "message": "Mismatched references",
             "help": "The in-text citation numbers do not match your numbered references. Make sure you are using square brackets citation style.",
@@ -88,8 +103,8 @@
             }
         },
         "incomplete_reference": {
-            "message": "An entry in the reference section appears to be incomplete",
-            "help": "Find the numbered entry in your reference section and add the missing elements. If we did not correctly recognize the entry's type, the warning may be invalid.",
+            "message": "An entry in the reference section might be incomplete",
+            "help": "Find the numbered entry in your reference section and check for the missing elements. If we did not correctly recognize the entry's type, the warning may be invalid.",
             "tex": {
                 "help": "Check that the missing elements are in your Bibtex. If you see them but they don't appear in the PDF, you may have them in the wrong Bibtex field"
             }

--- a/messages.json
+++ b/messages.json
@@ -72,6 +72,13 @@
                 "help": "Make sure you used the \\bibliographystyle{abbrv} and \\bibliography{sigproc} (or whatever your .bib file is named instead of sigproc.bib) commands in your paper."
             }
         },
+        "mismatched_refs": {
+            "message": "Mismatched references",
+            "help": "The in-text citation numbers do not match your numbered references. Make sure you are using square brackets citation style.",
+            "tex": {
+                "help": "Make sure you used the appropriate \\cite command and square brackets citation style."
+            }
+        },
         "alt_text_missing": {
             "message": "Missing alt text for image",
             "help": "Follow the instructions in the template for adding alt text to images. Every image needs alt text to ensure the paper can be understood by people using screen reader software. Additionally, alt text is used by the HTML conversion program to identify each image, so alt text must be unique for each image; things like image sizes may be wrong otherwise.",

--- a/shared_utils.py
+++ b/shared_utils.py
@@ -156,7 +156,7 @@ def check_styles(soup: bs4.BeautifulSoup,output_dir) -> None:
     ref_requirements["report"] = [ "author", "title", "date", "publisher"]
     ref_requirements["chapter"] =  ["author", "title", "date", "publisher", "editor", "container-title", "pages", "location"]
     ref_requirements["paper-conference"] = [ "author", "title", "date", "container-title", "pages"]
-    ref_requirements["article-journal"] = [ "author", "title", "date", "container-title", "pages", "volume", "issue"]
+    ref_requirements["article-journal"] = [ "author", "title", "date", "container-title", "pages", "volume" ] #"issue" is false alarming too much to be useful; TODO train anystyle on EDM style
     
     for i,ref_dict in enumerate(ref_dict_list,start=1):
         reqs = set(ref_requirements[ref_dict['type']])

--- a/shared_utils.py
+++ b/shared_utils.py
@@ -121,7 +121,7 @@ def check_styles(soup: bs4.BeautifulSoup,output_dir) -> None:
         warn('style_no_refs')
     # Check every numbered reference appears in the text in square brackets
     dom = etree.HTML(str(soup))
-    ref_lis = dom.xpath("//h1[contains(translate(text(), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'),'references')]/following-sibling::ol/li | //h1[.//*[contains(translate(text(), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'),'references')]]/following-sibling::ol/li") 
+    ref_lis = dom.xpath("//h1[contains(translate(text(), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'),'references')]/following-sibling::ol[1]/li | //h1[.//*[contains(translate(text(), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'),'references')]]/following-sibling::ol[1]/li") 
     # we found no references in the reference section!
     if ref_lis == []:
         warn('no_references_found_in_reference_section')


### PR DESCRIPTION
This PR adds a check that compares all in-text citations, e.g. "[1]" with the numbered references. If there are in-text citations that don't match the references, or vice-versa, a warning is displayed with all orphaned references.